### PR TITLE
Fixing the `SRCREV` for meta-arrow-sockit.

### DIFF
--- a/recipes-gsrd/altera-gsrd-pio-interrupt/altera-gsrd-pio-interrupt_1.0.bb
+++ b/recipes-gsrd/altera-gsrd-pio-interrupt/altera-gsrd-pio-interrupt_1.0.bb
@@ -11,9 +11,8 @@ PV = "0.1"
 
 REFDES_REPO ?= "git://github.com/altera-opensource/linux-refdesigns.git"
 REFDES_PROT ?= "http"
-REFDES_BRANCH ?= "socfpga-16.1"
-SRCREV = "a3d4e657087dbf535401b18cdd810591857b6961"
+SRCREV = "504ab64ac09b332ad9af4d46e65be4e93d4d74c3"
 
-SRC_URI = "${REFDES_REPO};protocol=${REFDES_PROT};branch=${REFDES_BRANCH} "
+SRC_URI = "${REFDES_REPO};protocol=${REFDES_PROT} "
 
 S = "${WORKDIR}/git/pio-interrupt"


### PR DESCRIPTION
The branch `socfpga-16.1` is not available.
Futhermore, the commit-id `a3d4e657087dbf535401b18cdd810591857b6961` only appears in tags such as  `ACDS16.1_REL_GSRD_RC7`, this will fail the `SRCREV` check(As it is not in any of the branch). 

Replacing with a similar commit `504ab64ac09b332ad9af4d46e65be4e93d4d74c3`(only added README.md) fixes  the problem.

Reference:
https://github.com/altera-opensource/linux-refdesigns/compare/a3d4e657087dbf535401b18cdd810591857b6961..504ab64ac09b332ad9af4d46e65be4e93d4d74c3